### PR TITLE
Fix update for urxvt

### DIFF
--- a/cwriter/writer_posix.go
+++ b/cwriter/writer_posix.go
@@ -21,7 +21,7 @@ func init() {
 
 func (w *Writer) clearLines() {
 	for i := 0; i < w.lineCount; i++ {
-		fmt.Fprintf(w.out, "%c[%dA", ESC, 0) // move the cursor up
+		fmt.Fprintf(w.out, "%c[%dA", ESC, 1) // move the cursor up
 		fmt.Fprintf(w.out, "%c[2K\r", ESC)   // clear the line
 	}
 }


### PR DESCRIPTION
Move the cursor one line up instead of zero lines. This fixes the bar updates with urxvt, which does nothing otherwise. Also verified to work on libvte and xterm.

Before:

![before](https://cloud.githubusercontent.com/assets/123276/22199671/3d551bf4-e15c-11e6-8ac8-45fdc5da938f.gif)

After:

![after](https://cloud.githubusercontent.com/assets/123276/22199691/4dc29912-e15c-11e6-87af-2053e32e3801.gif)

