### PR TITLE
(bar&progress) remove context dependency, use a channel instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: go
 install:
   - go get ./...
 go:
-  - 1.7.3
+  - 1.8
+  - 1.7
+  - 1.6
+  - 1.5
   - tip

--- a/example/cancel/main.go
+++ b/example/cancel/main.go
@@ -1,3 +1,5 @@
+//+build go1.7
+
 package main
 
 import (
@@ -19,7 +21,7 @@ func main() {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
-	p := mpb.New(ctx).SetWidth(64)
+	p := mpb.NewWithCtx(ctx).SetWidth(64)
 
 	name1 := "Bar#1: "
 	bar1 := p.AddBar(50).

--- a/example/hang/main.go
+++ b/example/hang/main.go
@@ -19,7 +19,7 @@ func main() {
 		return fmt.Sprintf("%8s", str)
 	}
 
-	p := mpb.New(nil)
+	p := mpb.New()
 	bar := p.AddBar(totalItem).PrependFunc(decor).AppendETA(-6)
 
 	blockSize := rand.Intn(maxBlockSize) + 1

--- a/example/io/multiple/main.go
+++ b/example/io/multiple/main.go
@@ -19,7 +19,7 @@ func main() {
 	url2 := "https://homebrew.bintray.com/bottles/libtiff-4.0.7.sierra.bottle.tar.gz"
 
 	var wg sync.WaitGroup
-	p := mpb.New(nil).SetWidth(60)
+	p := mpb.New().SetWidth(60)
 
 	for i, url := range [...]string{url1, url2} {
 		wg.Add(1)

--- a/example/io/single/main.go
+++ b/example/io/single/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 	defer dest.Close()
 
-	p := mpb.New(nil).SetWidth(64)
+	p := mpb.New().SetWidth(64)
 
 	bar := p.AddBar(size).PrependCounters(mpb.UnitBytes, 20).AppendETA(-6)
 

--- a/example/prependETA/main.go
+++ b/example/prependETA/main.go
@@ -16,7 +16,7 @@ const (
 func main() {
 
 	var wg sync.WaitGroup
-	p := mpb.New(nil).SetWidth(64)
+	p := mpb.New().SetWidth(64)
 	// p := mpb.New(nil).RefreshRate(80 * time.Millisecond).SetWidth(64)
 
 	name1 := "Bar#1: "

--- a/example/prependElapsed/main.go
+++ b/example/prependElapsed/main.go
@@ -16,7 +16,7 @@ const (
 func main() {
 
 	var wg sync.WaitGroup
-	p := mpb.New(nil).SetWidth(64)
+	p := mpb.New().SetWidth(64)
 	// p := mpb.New(nil).RefreshRate(80 * time.Millisecond).SetWidth(64)
 
 	name1 := "Bar#1: "

--- a/example/remove/main.go
+++ b/example/remove/main.go
@@ -16,7 +16,7 @@ const (
 func main() {
 
 	var wg sync.WaitGroup
-	p := mpb.New(nil).SetWidth(64)
+	p := mpb.New().SetWidth(64)
 	// p := mpb.New(nil).RefreshRate(100 * time.Millisecond).SetWidth(64)
 
 	name1 := "Bar#1: "

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	var wg sync.WaitGroup
-	p := mpb.New(nil)
+	p := mpb.New()
 	for i := 0; i < 3; i++ {
 		wg.Add(1) // add wg delta
 		name := fmt.Sprintf("Bar#%d:", i)

--- a/example/singleBar/main.go
+++ b/example/singleBar/main.go
@@ -11,7 +11,7 @@ func main() {
 	// Star mpb's rendering goroutine.
 	// If you don't plan to cancel, feed with nil
 	// otherwise provide context.Context, see cancel example
-	p := mpb.New(nil)
+	p := mpb.New()
 	// Set custom width for every bar, which mpb will contain
 	// The default one in 70
 	p.SetWidth(80)

--- a/example/sort/main.go
+++ b/example/sort/main.go
@@ -44,7 +44,7 @@ func percentage(total, current int64, ratio int) int {
 func main() {
 
 	var wg sync.WaitGroup
-	p := mpb.New(nil).SetWidth(60).BeforeRenderFunc(sortByProgressFunc())
+	p := mpb.New().SetWidth(60).BeforeRenderFunc(sortByProgressFunc())
 
 	name1 := "Bar#1: "
 	bar1 := p.AddBar(100).

--- a/example/stress/main.go
+++ b/example/stress/main.go
@@ -16,7 +16,7 @@ const (
 
 func main() {
 
-	p := mpb.New(nil)
+	p := mpb.New()
 	var wg sync.WaitGroup
 	wg.Add(totalBars)
 

--- a/example_test.go
+++ b/example_test.go
@@ -12,7 +12,7 @@ func Example() {
 	// Star mpb's rendering goroutine.
 	// If you don't plan to cancel, feed with nil
 	// otherwise provide context.Context, see cancel example
-	p := mpb.New(nil)
+	p := mpb.New()
 	// Set custom width for every bar, which mpb will contain
 	// The default one in 70
 	p.SetWidth(80)
@@ -37,7 +37,7 @@ func Example() {
 }
 
 func ExampleBar_InProgress() {
-	p := mpb.New(nil)
+	p := mpb.New()
 	bar := p.AddBar(100).AppendPercentage()
 
 	for bar.InProgress() {
@@ -53,7 +53,7 @@ func ExampleBar_PrependFunc() {
 	}
 
 	totalItem := 100
-	p := mpb.New(nil)
+	p := mpb.New()
 	bar := p.AddBar(int64(totalItem)).PrependFunc(decor)
 
 	for i := 0; i < totalItem; i++ {
@@ -69,7 +69,7 @@ func ExampleBar_AppendFunc() {
 	}
 
 	totalItem := 100
-	p := mpb.New(nil)
+	p := mpb.New()
 	bar := p.AddBar(int64(totalItem)).AppendFunc(decor)
 
 	for i := 0; i < totalItem; i++ {

--- a/progress.go
+++ b/progress.go
@@ -1,7 +1,6 @@
 package mpb
 
 import (
-	"context"
 	"errors"
 	"io"
 	"log"
@@ -58,8 +57,6 @@ const (
 
 // Progress represents the container that renders Progress bars
 type Progress struct {
-	// Context for canceling bars rendering
-	ctx context.Context
 	// WaitGroup for internal rendering sync
 	wg *sync.WaitGroup
 
@@ -72,16 +69,12 @@ type Progress struct {
 	outChangeReqCh chan io.Writer
 	barCountReqCh  chan chan int
 	brCh           chan BeforeRender
+	stopCh         chan struct{}
 	done           chan struct{}
 }
 
-// New creates new Progress instance, which will orchestrate bars rendering
-// process. It acceepts context.Context, for cancellation.
-// If you don't plan to cancel, it is safe to feed with nil
-func New(ctx context.Context) *Progress {
-	if ctx == nil {
-		ctx = context.Background()
-	}
+// New Progress instance, it orchestrates the rendering of progress bars.
+func New() *Progress {
 	p := &Progress{
 		width:          pwidth,
 		operationCh:    make(chan *operation),
@@ -89,9 +82,9 @@ func New(ctx context.Context) *Progress {
 		outChangeReqCh: make(chan io.Writer),
 		barCountReqCh:  make(chan chan int),
 		brCh:           make(chan BeforeRender),
+		stopCh:         make(chan struct{}),
 		done:           make(chan struct{}),
 		wg:             new(sync.WaitGroup),
-		ctx:            ctx,
 	}
 	go p.server(cwriter.New(os.Stdout), time.NewTicker(rr*time.Millisecond))
 	return p
@@ -151,7 +144,7 @@ func (p *Progress) AddBarWithID(id int, total int64) *Bar {
 		panic(ErrCallAfterStop)
 	}
 	result := make(chan bool)
-	bar := newBar(p.ctx, p.wg, id, total, p.width, p.format)
+	bar := newBar(p.wg, id, total, p.width, p.format)
 	p.operationCh <- &operation{barAdd, bar, result}
 	if <-result {
 		p.wg.Add(1)
@@ -193,10 +186,10 @@ func (p *Progress) Format(format string) *Progress {
 
 // Stop waits for bars to finish rendering and stops the rendering goroutine
 func (p *Progress) Stop() {
-	p.wg.Wait()
 	if isClosed(p.done) {
 		return
 	}
+	p.stopCh <- struct{}{}
 	close(p.operationCh)
 }
 
@@ -216,6 +209,7 @@ func (p *Progress) server(cw *cwriter.Writer, t *time.Ticker) {
 		}
 		wg.Done()
 	}
+
 	for {
 		select {
 		case w := <-p.outChangeReqCh:
@@ -280,7 +274,11 @@ func (p *Progress) server(cw *cwriter.Writer, t *time.Ticker) {
 		case d := <-p.rrChangeReqCh:
 			t.Stop()
 			t = time.NewTicker(d)
-		case <-p.ctx.Done():
+		case <-p.stopCh:
+			for _, b := range bars {
+				b.Stop()
+			}
+		case <-p.done:
 			return
 		}
 	}

--- a/progress_go1.7.go
+++ b/progress_go1.7.go
@@ -1,0 +1,16 @@
+//+build go1.7
+
+package mpb
+
+import "context"
+
+// New Progress instance, it orchestrates the rendering of progress bars.
+// It supports cancellation via Context.
+func NewWithCtx(ctx context.Context) *Progress {
+	p := New()
+	go func() {
+		<-ctx.Done()
+		p.Stop()
+	}()
+	return p
+}

--- a/progress_test.go
+++ b/progress_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAddBar(t *testing.T) {
 	var buf bytes.Buffer
-	p := New(nil).SetWidth(60).SetOut(&buf)
+	p := New().SetWidth(60).SetOut(&buf)
 	count := p.BarCount()
 	if count != 0 {
 		t.Errorf("Count want: %q, got: %q\n", 0, count)
@@ -24,7 +24,7 @@ func TestAddBar(t *testing.T) {
 }
 
 func TestRemoveBar(t *testing.T) {
-	p := New(nil)
+	p := New()
 	b := p.AddBar(10)
 
 	if !p.RemoveBar(b) {


### PR DESCRIPTION
- This makes the library compatible with older versions of Go.
- Update `.travis.yml` to add more versions of go (2 yrs old release)