### PR TITLE
add ability to manually refresh rather than refresh rate timer

### DIFF
--- a/progress_windows.go
+++ b/progress_windows.go
@@ -3,24 +3,38 @@
 package mpb
 
 func (p *Progress) serve(s *pState) {
+	// common operation for ticker for manual refresh, returns
+	// bool to indicate if we are done [false] or should continue [true]
+	tickRefresh := func() bool {
+		if s.zeroWait {
+			s.ticker.Stop()
+			if s.shutdownNotifier != nil {
+				close(s.shutdownNotifier)
+			}
+			close(p.done)
+			close(p.refresh)
+			return false
+		}
+		tw, err := s.cw.GetWidth()
+		if err != nil {
+			tw = s.width
+		}
+		s.render(tw)
+		return true
+	}
+
 	for {
 		select {
 		case op := <-p.operateState:
 			op(s)
 		case <-s.ticker.C:
-			if s.zeroWait {
-				s.ticker.Stop()
-				if s.shutdownNotifier != nil {
-					close(s.shutdownNotifier)
-				}
-				close(p.done)
+			if !tickRefresh() {
 				return
 			}
-			tw, err := s.cw.GetWidth()
-			if err != nil {
-				tw = s.width
+		case <-p.refresh:
+			if !tickRefresh() {
+				return
 			}
-			s.render(tw)
 		}
 	}
 }


### PR DESCRIPTION
Hi Vladimir, thanks for your library, it is very interesting!  It took me a few hours to really understand how you were doing it, but it is a very nice design!

This PR will allow for manually refreshing the bars, instead of just using timer based.  My use-case is that I am monitoring something via subprocess and I want to update the progress bars only when I get information from the subprocess.  To do this I added a manual `p.Refresh()` function and I use it in conjunction with a really long refresh rate, something like `mpb.WithRefreshRate(time.Hour)`.  

The main reason I want to only refresh when necessary is that my tool records stdout/stderr to a log file so that I can later debug user sessions, and I want to minimize the progress bar updates so the log file does not become excessively long.

I was thinking about a way to disable the automatic refresh rate, but I wanted to get your thoughts before I put any more effort into this.  I am fine with the `time.Hour` refresh rate hack, but if you are interested in the PR then I can look into some approaches.

Thank you!
-Cory