### PR TITLE
Allow multi-rune strings as BarFiller.

### DIFF
--- a/_examples/fillerComplex/go.mod
+++ b/_examples/fillerComplex/go.mod
@@ -2,4 +2,6 @@ module github.com/vbauerster/mpb/_examples/fillerComplex
 
 go 1.14
 
-require github.com/vbauerster/mpb/v6 v6.0.2
+require github.com/vbauerster/mpb/v6 v6.0.3
+
+// replace github.com/vbauerster/mpb/v6 => ../../

--- a/_examples/fillerComplex/go.mod
+++ b/_examples/fillerComplex/go.mod
@@ -1,0 +1,5 @@
+module github.com/vbauerster/mpb/_examples/fillerComplex
+
+go 1.14
+
+require github.com/vbauerster/mpb/v6 v6.0.2

--- a/_examples/fillerComplex/main.go
+++ b/_examples/fillerComplex/main.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/vbauerster/mpb/v6"
-	"github.com/vbauerster/mpb/v6/complexfiller"
+	complexfiller "github.com/vbauerster/mpb/v6/complexfiller"
 	"github.com/vbauerster/mpb/v6/decor"
 )
 

--- a/_examples/fillerComplex/main.go
+++ b/_examples/fillerComplex/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/vbauerster/mpb/v6"
+	"github.com/vbauerster/mpb/v6/decor"
+)
+
+func main() {
+	// initialize progress container, with custom width
+	p := mpb.New(mpb.WithWidth(64))
+
+	total := 100
+	name := "Complex Filler:"
+	bar := p.Add(int64(total),
+		// NewBarComplexFiller allows for multi-rune strings
+		mpb.NewBarComplexFiller("[\u001b[36;1m", "_", "\u001b[0m⛵\u001b[36;1m", "_", "\u001b[0m]"),
+		mpb.PrependDecorators(
+			// simple name decorator
+			decor.Name(name),
+		),
+		mpb.AppendDecorators(decor.Percentage()),
+	)
+	// simulating some work
+	max := 100 * time.Millisecond
+	for i := 0; i < total; i++ {
+		time.Sleep(time.Duration(rand.Intn(10)+1) * max / 10)
+		bar.Increment()
+	}
+	// wait for our bar to complete
+	p.Wait()
+}

--- a/_examples/fillerComplex/main.go
+++ b/_examples/fillerComplex/main.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/vbauerster/mpb/v6"
+	"github.com/vbauerster/mpb/v6/complexfiller"
 	"github.com/vbauerster/mpb/v6/decor"
 )
 
@@ -16,7 +17,7 @@ func main() {
 	name := "Complex Filler:"
 	bar := p.Add(int64(total),
 		// NewBarComplexFiller allows for multi-rune strings
-		mpb.NewBarComplexFiller("[\u001b[36;1m", "_", "\u001b[0m⛵\u001b[36;1m", "_", "\u001b[0m]"),
+		complexfiller.NewBarFiller("[\u001b[36;1m", "_", "\u001b[0m⛵\u001b[36;1m", "_", "\u001b[0m]", "\u001b[0m⛵\u001b[36;1m"),
 		mpb.PrependDecorators(
 			// simple name decorator
 			decor.Name(name),

--- a/complexfiller/bar_filler.go
+++ b/complexfiller/bar_filler.go
@@ -1,0 +1,34 @@
+package complexfiller
+
+import (
+	"io"
+
+	"github.com/vbauerster/mpb/v6/decor"
+)
+
+// BarFiller interface.
+// Bar (without decorators) renders itself by calling BarFiller's Fill method.
+//
+//	reqWidth is requested width, set by `func WithWidth(int) ContainerOption`.
+//	If not set, it defaults to terminal width.
+//
+// Default implementations can be obtained via:
+//
+//	func NewBarFiller(style string) BarFiller
+//	func NewBarFillerRev(style string) BarFiller
+//	func NewBarFillerPick(style string, rev bool) BarFiller
+//	func NewBarComplexFiller(style string) BarFiller
+//	func NewBarComplexFillerRev(style string) BarFiller
+//	func NewBarComplexFillerPick(style string, rev bool) BarFiller
+//	func NewSpinnerFiller(style []string, alignment SpinnerAlignment) BarFiller
+//
+type BarFiller interface {
+	Fill(w io.Writer, reqWidth int, stat decor.Statistics)
+}
+
+// BarFillerFunc is function type adapter to convert function into BarFiller.
+type BarFillerFunc func(w io.Writer, reqWidth int, stat decor.Statistics)
+
+func (f BarFillerFunc) Fill(w io.Writer, reqWidth int, stat decor.Statistics) {
+	f(w, reqWidth, stat)
+}

--- a/complexfiller/bar_filler.go
+++ b/complexfiller/bar_filler.go
@@ -17,9 +17,9 @@ import (
 //	func NewBarFiller(style string) BarFiller
 //	func NewBarFillerRev(style string) BarFiller
 //	func NewBarFillerPick(style string, rev bool) BarFiller
-//	func NewBarComplexFiller(style string) BarFiller
-//	func NewBarComplexFillerRev(style string) BarFiller
-//	func NewBarComplexFillerPick(style string, rev bool) BarFiller
+//	func NewBarFiller(style string) BarFiller
+//	func NewBarFillerRev(style string) BarFiller
+//	func NewBarFillerPick(style string, rev bool) BarFiller
 //	func NewSpinnerFiller(style []string, alignment SpinnerAlignment) BarFiller
 //
 type BarFiller interface {

--- a/complexfiller/bar_filler_bar.go
+++ b/complexfiller/bar_filler_bar.go
@@ -23,7 +23,7 @@ const (
 	rRefill
 )
 
-// BarComplexDefaultStyle is a style for rendering a progress bar.
+// BarDefaultStyle is a style for rendering a progress bar.
 // It consists of a slice containing 7 ordered strings:
 //
 //	'1st string' stands for left boundary string
@@ -57,43 +57,44 @@ type space struct {
 	count  int
 }
 
-// NewBarComplexFiller returns a BarComplexFiller implementation which renders a
+// NewBarFiller returns a BarFiller implementation which renders a
 // progress bar in regular direction. If style is empty string,
 // BarDefaultStyle is applied. To be used with `*Progress.Add(...)
 // *Bar` method.
-func NewBarComplexFiller(style ...string) BarFiller {
-	return newBarComplexFiller(false, style...)
+func NewBarFiller(style ...string) BarFiller {
+	return newBarFiller(false, style...)
 }
 
-// NewBarComplexFillerRev returns a BarComplexFiller implementation which renders a
+// NewBarFillerRev returns a BarFiller implementation which renders a
 // progress bar in reverse direction. If style is empty string,
 // BarDefaultStyle is applied. To be used with `*Progress.Add(...)
 // *Bar` method.
-func NewBarComplexFillerRev(style ...string) BarFiller {
-	return newBarComplexFiller(true, style...)
+func NewBarFillerRev(style ...string) BarFiller {
+	return newBarFiller(true, style...)
 }
 
-// NewBarComplexFillerPick pick between regular and reverse BarComplexFiller implementation
+// newBarFillerPick pick between regular and reverse BarFiller implementation
 // based on rev param. To be used with `*Progress.Add(...) *Bar` method.
-func NewBarComplexFillerPick(rev bool, style ...string) BarFiller {
-	return newBarComplexFiller(rev, style...)
+func NewBarFillerPick(rev bool, style ...string) BarFiller {
+	return newBarFiller(rev, style...)
 }
 
-func newBarComplexFiller(rev bool, style ...string) BarFiller {
+func newBarFiller(rev bool, style ...string) BarFiller {
 	bf := &barFiller{
 		format:  make([][]byte, len(BarDefaultStyle)),
 		rwidth:  make([]int, len(BarDefaultStyle)),
 		reverse: rev,
 	}
+	bf.parse(BarDefaultStyle)
 	if len(style) != 0 && !reflect.DeepEqual(style, BarDefaultStyle) {
-		bf.parseComplex(style)
+		bf.parse(style)
 	} else {
-		bf.parseComplex(BarDefaultStyle)
+		bf.parse(BarDefaultStyle)
 	}
 	return bf
 }
 
-func (s *barFiller) parseComplex(style []string) {
+func (s *barFiller) parse(style []string) {
 	srcFormat := make([][]byte, 0, len(BarDefaultStyle))
 	srcRwidth := make([]int, 0, len(BarDefaultStyle))
 	for _, el := range style {

--- a/complexfiller/bar_filler_bar.go
+++ b/complexfiller/bar_filler_bar.go
@@ -1,0 +1,210 @@
+package complexfiller
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"regexp"
+	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
+	"github.com/vbauerster/mpb/v6/decor"
+	"github.com/vbauerster/mpb/v6/internal"
+)
+
+const (
+	rLeft = iota
+	rFill
+	rTip
+	rSpace
+	rRight
+	rRevTip
+	rRefill
+)
+
+// BarComplexDefaultStyle is a style for rendering a progress bar.
+// It consists of a slice containing 7 ordered strings:
+//
+//	'1st string' stands for left boundary string
+//
+//	'2nd string' stands for fill string
+//
+//	'3rd string' stands for tip string
+//
+//	'4th string' stands for space string
+//
+//	'5th string' stands for right boundary string
+//
+//	'6th string' stands for reverse tip string
+//
+//	'7th stirng' stands for refill string
+//
+var BarDefaultStyle = []string{"[", "=", ">", "-", "]", "<", "+"}
+
+type barFiller struct {
+	format  [][]byte
+	rwidth  []int
+	tip     []byte
+	refill  int64
+	reverse bool
+	flush   func(io.Writer, *space, [][]byte)
+}
+
+type space struct {
+	space  []byte
+	rwidth int
+	count  int
+}
+
+// NewBarComplexFiller returns a BarComplexFiller implementation which renders a
+// progress bar in regular direction. If style is empty string,
+// BarDefaultStyle is applied. To be used with `*Progress.Add(...)
+// *Bar` method.
+func NewBarComplexFiller(style ...string) BarFiller {
+	return newBarComplexFiller(false, style...)
+}
+
+// NewBarComplexFillerRev returns a BarComplexFiller implementation which renders a
+// progress bar in reverse direction. If style is empty string,
+// BarDefaultStyle is applied. To be used with `*Progress.Add(...)
+// *Bar` method.
+func NewBarComplexFillerRev(style ...string) BarFiller {
+	return newBarComplexFiller(true, style...)
+}
+
+// NewBarComplexFillerPick pick between regular and reverse BarComplexFiller implementation
+// based on rev param. To be used with `*Progress.Add(...) *Bar` method.
+func NewBarComplexFillerPick(rev bool, style ...string) BarFiller {
+	return newBarComplexFiller(rev, style...)
+}
+
+func newBarComplexFiller(rev bool, style ...string) BarFiller {
+	bf := &barFiller{
+		format:  make([][]byte, len(BarDefaultStyle)),
+		rwidth:  make([]int, len(BarDefaultStyle)),
+		reverse: rev,
+	}
+	if len(style) != 0 && !reflect.DeepEqual(style, BarDefaultStyle) {
+		bf.parseComplex(style)
+	} else {
+		bf.parseComplex(BarDefaultStyle)
+	}
+	return bf
+}
+
+func (s *barFiller) parseComplex(style []string) {
+	srcFormat := make([][]byte, 0, len(BarDefaultStyle))
+	srcRwidth := make([]int, 0, len(BarDefaultStyle))
+	for _, el := range style {
+		if !utf8.ValidString(el) {
+			panic("invalid bar style")
+		}
+		tmpFormat := []byte{}
+		tmpRwidth := 0
+		gr := uniseg.NewGraphemes(el)
+		for gr.Next() {
+			tmpFormat = append(tmpFormat, gr.Bytes()...)
+			tmpRwidth += runewidth.StringWidth(gr.Str())
+		}
+
+		// Width fix for Bash colour codes, `NewGraphemes()` treats like normal characters (makes sense)
+		r := regexp.MustCompile(`\[[0-9;]+m`)
+		matches := r.FindAllString(el, -1)
+		for _, el := range matches {
+			for range el {
+				tmpRwidth--
+			}
+		}
+
+		srcFormat = append(srcFormat, tmpFormat)
+		srcRwidth = append(srcRwidth, tmpRwidth)
+	}
+	copy(s.format, srcFormat)
+	copy(s.rwidth, srcRwidth)
+	if s.reverse {
+		s.tip = s.format[rRevTip]
+		s.flush = reverseFlush
+	} else {
+		s.tip = s.format[rTip]
+		s.flush = regularFlush
+	}
+}
+
+func (s *barFiller) Fill(w io.Writer, reqWidth int, stat decor.Statistics) {
+	width := internal.CheckRequestedWidth(reqWidth, stat.AvailableWidth)
+	brackets := s.rwidth[rLeft] + s.rwidth[rRight]
+	if width < brackets {
+		return
+	}
+	// don't count brackets as progress
+	width -= brackets
+
+	w.Write(s.format[rLeft])
+	defer w.Write(s.format[rRight])
+
+	cwidth := int(internal.PercentageRound(stat.Total, stat.Current, width))
+	space := &space{
+		space:  s.format[rSpace],
+		rwidth: s.rwidth[rSpace],
+		count:  width - cwidth,
+	}
+
+	index, refill := 0, 0
+	bb := make([][]byte, cwidth)
+
+	if cwidth > 0 && cwidth != width {
+		bb[index] = s.tip
+		cwidth -= s.rwidth[rTip]
+		index++
+	}
+
+	if stat.Refill > 0 {
+		refill = int(internal.PercentageRound(stat.Total, int64(stat.Refill), width))
+		if refill > cwidth {
+			refill = cwidth
+		}
+		cwidth -= refill
+	}
+
+	for cwidth > 0 {
+		bb[index] = s.format[rFill]
+		cwidth -= s.rwidth[rFill]
+		index++
+	}
+
+	for refill > 0 {
+		bb[index] = s.format[rRefill]
+		refill -= s.rwidth[rRefill]
+		index++
+	}
+
+	if cwidth+refill < 0 || space.rwidth > 1 {
+		buf := new(bytes.Buffer)
+		s.flush(buf, space, bb[:index])
+		io.WriteString(w, runewidth.Truncate(buf.String(), width, "…"))
+		return
+	}
+
+	s.flush(w, space, bb)
+}
+
+func regularFlush(w io.Writer, space *space, bb [][]byte) {
+	for i := len(bb) - 1; i >= 0; i-- {
+		w.Write(bb[i])
+	}
+	for space.count > 0 {
+		w.Write(space.space)
+		space.count -= space.rwidth
+	}
+}
+
+func reverseFlush(w io.Writer, space *space, bb [][]byte) {
+	for space.count > 0 {
+		w.Write(space.space)
+		space.count -= space.rwidth
+	}
+	for i := 0; i < len(bb); i++ {
+		w.Write(bb[i])
+	}
+}


### PR DESCRIPTION
Before:
```go
mpb.NewBarFiller("╢▌▌░╟")
// or
NewBarFillerPick("", true) // Empty returns default bar filler
```
After:
```go
mpb.NewBarFiller("╢","▌","▌","░","╟")
// or
NewBarFillerPick(true) // Spread operator after, ie "(true, "[", "=", etc..)"
```

Keeps all previous mechanics in place, such as `uniseg.NewGraphemes()`, and `utf8.ValidString()`. Added edge case for Bash colour codes to fix the width. Tested with all examples, works fine. Testing with my own custom filler (with colours), works fine:
```go
mpb.NewBarFiller("\u001b[36;1m", "_", "\u001b[30;1m|\\\u001b[36;1m", "_", "\u001b[0m") // Shark :P
```
![](https://bn1302files.storage.live.com/y4mue5XdbswzWU_WvfXgkJPdx8ixRI_HrkWb8zuqIP9UDXQhmU0jFbXKQCaoJHhkb9z1I4gqiRDcWwfa9WHCu1-CMO8Oq_r3bnWX60G9T619qmcvTdd_Svrc2-Sp39LjmYgEWklaix1Ue0XkqLcB8oKWTt1QyDPzfEpUn44NsnZals_LTBPxUOlTxELvGDgsZfe?width=1051&height=29&cropmode=none)
> Note: when using Bash colour codes, there seems to be a reflow on the first frame (while width is calculated). I don't think this really matters, as it also takes a frame to calculate the width on normal bars.

Updated docs and examples as best as I can see, everything compiles and runs no problem. Please let me know if I overlooked something.