### PR TITLE
Add support for z/OS

### DIFF
--- a/cwriter/util_zos.go
+++ b/cwriter/util_zos.go
@@ -1,0 +1,7 @@
+// +build zos
+
+package cwriter
+
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TCGETS


### PR DESCRIPTION
This addition enables support for building on z/OS. It should have no impact on building on other platforms.