### PR TITLE
progress: always force a render on shutdown

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -222,10 +222,8 @@ func (p *Progress) serve(s *pState, cw *cwriter.Writer) {
 				p.dlogger.Println(err)
 			}
 		case <-s.shutdownNotifier:
-			for s.heapUpdated {
-				if err := s.render(cw); err != nil {
-					p.dlogger.Println(err)
-				}
+			if err := s.render(cw); err != nil {
+				p.dlogger.Println(err)
 			}
 			return
 		}


### PR DESCRIPTION
fix a race issue where a cancelled context might cause the progress
bar to never be rendered.

More details here: https://github.com/containers/image/issues/1013

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>