### PR TITLE
Fix build on windows

### DIFF
--- a/cwriter/writer_windows.go
+++ b/cwriter/writer_windows.go
@@ -26,7 +26,7 @@ func (w *Writer) clearLines() error {
 		return err
 	}
 
-	info.CursorPosition.Y -= int16(w.lineCount)
+	info.CursorPosition.Y -= int16(w.lines)
 	if info.CursorPosition.Y < 0 {
 		info.CursorPosition.Y = 0
 	}
@@ -40,7 +40,7 @@ func (w *Writer) clearLines() error {
 		X: info.Window.Left,
 		Y: info.CursorPosition.Y,
 	}
-	count := uint32(info.Size.X) * uint32(w.lineCount)
+	count := uint32(info.Size.X) * uint32(w.lines)
 	_, _, _ = procFillConsoleOutputCharacter.Call(
 		uintptr(w.fd),
 		uintptr(' '),


### PR DESCRIPTION
After commit c232068dd380937ce0a96f3abe5ec0f3990417fc :
> cwriter/writer_windows.go:29:34: w.lineCount undefined (type *Writer has no field or method lineCount)
> cwriter/writer_windows.go:43:41: w.lineCount undefined (type *Writer has no field or method lineCount)

(I have only tested that this compiles.)