### PR TITLE
add write interface for print log

### DIFF
--- a/cwriter/writer.go
+++ b/cwriter/writer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"sync"
 )
 
 // ErrNotTTY not a TeleTYpewriter error.
@@ -20,11 +21,13 @@ const (
 // Writer is a buffered the writer that updates the terminal. The
 // contents of writer will be flushed when Flush is called.
 type Writer struct {
-	out        io.Writer
-	buf        bytes.Buffer
-	lines      int
-	fd         int
-	isTerminal bool
+	sync.Mutex
+	out                io.Writer
+	buf                bytes.Buffer
+	lines              int
+	fd                 int
+	isTerminal         bool
+	LastTypeIsProgress bool
 }
 
 // New returns a new Writer with defaults.
@@ -39,15 +42,18 @@ func New(out io.Writer) *Writer {
 
 // Flush flushes the underlying buffer.
 func (w *Writer) Flush(lines int) (err error) {
+	w.Lock()
+	defer w.Unlock()
 	// some terminals interpret 'cursor up 0' as 'cursor up 1'
-	if w.lines > 0 {
-		err = w.clearLines()
+	if w.LastTypeIsProgress && w.lines > 0 {
+		err = w.ClearLines()
 		if err != nil {
 			return
 		}
 	}
 	w.lines = lines
 	_, err = w.buf.WriteTo(w.out)
+	w.LastTypeIsProgress = true
 	return
 }
 

--- a/cwriter/writer_posix.go
+++ b/cwriter/writer_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cwriter
@@ -6,7 +7,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (w *Writer) ClearLines() error {
+func (w *Writer) clearLines() error {
 	return w.ansiCuuAndEd()
 }
 

--- a/cwriter/writer_posix.go
+++ b/cwriter/writer_posix.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (w *Writer) clearLines() error {
+func (w *Writer) ClearLines() error {
 	return w.ansiCuuAndEd()
 }
 

--- a/cwriter/writer_posix.go
+++ b/cwriter/writer_posix.go
@@ -1,4 +1,3 @@
-//go:build !windows
 // +build !windows
 
 package cwriter


### PR DESCRIPTION
We can add a write interface for the use of external log modules to solve the problem of overlapping the log and the progress bar. The following is the usage

```
package main

import (
	"github.com/vbauerster/mpb/v7"
	"github.com/vbauerster/mpb/v7/decor"
	"log"
	"math/rand"
	"os"
	"time"
)

func main() {
	log.Println("start")
	// initialize progress container, with custom width
	p := mpb.New(mpb.WithWidth(64))
	log.SetOutput(p)
	total := 10
	name := "Single Bar:"
	// create a single bar, which will inherit container's width
	bar := p.New(int64(total),
		// BarFillerBuilder with custom style
		mpb.BarStyle().Lbound("╢").Filler("▌").Tip("▌").Padding("░").Rbound("╟"),
		mpb.PrependDecorators(
			// display our name with one space on the right
			decor.Name(name, decor.WC{W: len(name) + 1, C: decor.DidentRight}),
			// replace ETA decorator with "done" message, OnComplete event
			decor.OnComplete(
				decor.AverageETA(decor.ET_STYLE_GO, decor.WC{W: 4}), "done",
			),
		),
		mpb.AppendDecorators(decor.Percentage()),
	)
	// simulating some work
	max := 100 * time.Millisecond

	for i := 0; i < total; i++ {
		time.Sleep(time.Duration(rand.Intn(10)+1) * max / 10)
		bar.Increment()
		log.Printf("%d:%s", i, time.Now().String())
		if i == 1 {
			go func() {
				for i := 0; i < 5; i++ {
					log.Printf("other goroutines %d:%s", i, time.Now().String())
					time.Sleep(time.Duration(rand.Intn(10)+1) * max / 10)
				}
			}()
		}
	}

	// wait for our bar to complete and flush
	p.Wait()
	log.SetOutput(os.Stderr)
	log.Println("end")
}

```
![Kapture 2022-02-17 at 20 46 47](https://user-images.githubusercontent.com/31313340/154485143-dcb55791-981d-4e02-b714-2bd3e3706a2a.gif)
