### PR TITLE
bar_option: Add BarFillerClearOnAbort helper function

### DIFF
--- a/bar_option.go
+++ b/bar_option.go
@@ -86,6 +86,25 @@ func BarFillerOnComplete(message string) BarOption {
 	})
 }
 
+// BarFillerClearOnAbort clears bar's filler on abort event.
+// It's shortcut for BarFillerOnAbort("").
+func BarFillerClearOnAbort() BarOption {
+	return BarFillerOnAbort("")
+}
+
+// BarFillerOnAbort replaces bar's filler with message, on abort event.
+func BarFillerOnAbort(message string) BarOption {
+	return BarFillerMiddleware(func(base BarFiller) BarFiller {
+		return BarFillerFunc(func(w io.Writer, st decor.Statistics) error {
+			if st.Aborted {
+				_, err := io.WriteString(w, message)
+				return err
+			}
+			return base.Fill(w, st)
+		})
+	})
+}
+
 // BarFillerMiddleware provides a way to augment the underlying BarFiller.
 func BarFillerMiddleware(middle func(BarFiller) BarFiller) BarOption {
 	if middle == nil {


### PR DESCRIPTION
We currently have helper function to clear the progress bar on complete but not on abort. I recently wanted to use this library and I need to clear the bar on both events. Although it can be achieved using `BarFillerMiddleware` directly, it would be nice to have this shortcut helper function.
Should we also add **CompleteOrAbort** version? If we add both `BarFillerClearOnAbort` and `BarFillerClearOnComplete` options to the bar, would it cause problems as both calls `base.Fill(w, st)` ?