### PR TITLE
fix(cwriter): restore AIX build of ioctlReadTermios

### DIFF
--- a/cwriter/util_aix.go
+++ b/cwriter/util_aix.go
@@ -1,0 +1,9 @@
+//go:build aix
+
+package cwriter
+
+import "golang.org/x/sys/unix"
+
+// util_linux.go is filename-constrained to GOOS=linux, so AIX needs its own
+// file even though it uses the same TCGETS constant (issue #150).
+const ioctlReadTermios = unix.TCGETS

--- a/cwriter/util_linux.go
+++ b/cwriter/util_linux.go
@@ -1,4 +1,4 @@
-//go:build aix || linux
+//go:build linux
 
 package cwriter
 


### PR DESCRIPTION
## Description

Cross-compiling for AIX failed with:

```text
cwriter/writer_posix.go:51:37: undefined: ioctlReadTermios
```

`cwriter/util_linux.go` used:

```go
//go:build aix || linux
const ioctlReadTermios = unix.TCGETS
```

But Go's filename build constraint treats `*_linux.go` as **linux-only**, so the file was ignored on `GOOS=aix` even though the line tag included `aix`. Result: `ioctlReadTermios` was undefined on AIX (issue #150).

## Fix

- Add `cwriter/util_aix.go` with `//go:build aix` and `unix.TCGETS`
- Narrow `cwriter/util_linux.go` to `//go:build linux`

AIX exposes `TCGETS` in `golang.org/x/sys/unix`, same value as Linux.

## Verification

```bash
GOOS=aix GOARCH=ppc64 go build -o /dev/null ./cwriter
GOOS=linux GOARCH=amd64 go build -o /dev/null ./cwriter
go test ./... -count=1
```

`go list` on AIX now includes `util_aix.go`; Linux still gets `util_linux.go`.

## Linked Issue

Closes #150
