### PR TITLE
docs: document WithWaitGroup error path

### DIFF
--- a/container_option.go
+++ b/container_option.go
@@ -16,6 +16,13 @@ type ContainerOption func(*pState)
 // *sync.WaitGroup is provided, you can safely call just p.Wait()
 // without calling Wait() on provided *sync.WaitGroup. Makes sense
 // when there are more than one bar to render.
+//
+// If a goroutine exits early (for example on error) before the bar
+// reaches its total, call (*Bar).Abort on that bar so p.Wait()
+// does not wait indefinitely for the bar to reach its total. The
+// provided *sync.WaitGroup must still be balanced: call wg.Add(1)
+// before starting each goroutine and defer wg.Done() inside it, even
+// on the error path.
 func WithWaitGroup(wg *sync.WaitGroup) ContainerOption {
 	return func(s *pState) {
 		s.uwg = wg


### PR DESCRIPTION
## What

Adds documentation to `WithWaitGroup` about the error path.

## Why

#130 reported `p.Wait()` hanging indefinitely when a goroutine exits early on error before the bar reaches its total. The user asked whether calling `(*Bar).Abort` on the error path is the correct pattern.

`Abort` is indeed the correct pattern, but this was not documented anywhere. `WithWaitGroup` only said you can call `p.Wait()` instead of `wg.Wait()`, without mentioning that bars still need to reach their total or be aborted.

## Change

Document that a goroutine which exits early (e.g. on error) before the bar reaches its total must call `(*Bar).Abort` on that bar, and that the `*sync.WaitGroup` must still be balanced with `wg.Add(1)` / `defer wg.Done()` even on the error path.

Closes #130