### PR TITLE
feat: add ProxyReadSeeker for io.ReadSeeker progress tracking

### DIFF
--- a/bar.go
+++ b/bar.go
@@ -69,7 +69,7 @@ type renderFrame struct {
 // already completed or aborted then value of `pr` is nil. If underlying
 // *Bar instance was initialized with total <= 0 then it's necessary to call
 // `(*Bar).SetTotal(-1, true)` after copy operation completes. Most of the
-// time it means that there is need to call `(*Bar).SetTotal(-1, true)` after
+// time it means that there is a need to call `(*Bar).SetTotal(-1, true)` after
 // io.Copy(dst, pr) returns.
 func (b *Bar) ProxyReader(r io.Reader) (pr io.ReadCloser) {
 	if r == nil {
@@ -79,6 +79,27 @@ func (b *Bar) ProxyReader(r io.Reader) (pr io.ReadCloser) {
 	select {
 	case b.operateState <- func(s *bState) { result <- len(s.ewmaDecorators) != 0 }:
 		return newProxyReader(r, b, <-result)
+	case <-b.ctx.Done():
+		return nil
+	}
+}
+
+// ProxyReadSeeker wraps io.ReadSeeker with metrics required for progress
+// tracking. It is the ReadSeeker counterpart of ProxyReader, intended for
+// use cases such as S3 multipart uploads where the AWS SDK requires an
+// io.ReadSeeker. Seek calls reset the bar's current value to the new
+// absolute offset so the bar stays in sync after retries or rewinds.
+// Panics if `rs` is nil. If `rs` is io.ReadCloser then calling Close on
+// the returned value will close the underlying reader. If underlying *Bar
+// instance is already completed or aborted then nil is returned.
+func (b *Bar) ProxyReadSeeker(rs io.ReadSeeker) io.ReadSeekCloser {
+	if rs == nil {
+		panic(errors.New("expected non nil io.ReadSeeker"))
+	}
+	result := make(chan bool, 1)
+	select {
+	case b.operateState <- func(s *bState) { result <- len(s.ewmaDecorators) != 0 }:
+		return newProxyReadSeeker(rs, b, <-result)
 	case <-b.ctx.Done():
 		return nil
 	}

--- a/proxyreadseeker.go
+++ b/proxyreadseeker.go
@@ -1,0 +1,66 @@
+package mpb
+
+import (
+	"io"
+	"time"
+)
+
+type proxyReadSeeker struct {
+	rs  io.ReadSeeker
+	bar *Bar
+}
+
+func (x proxyReadSeeker) Read(p []byte) (int, error) {
+	n, err := x.rs.Read(p)
+	x.bar.IncrBy(n)
+	return n, err
+}
+
+func (x proxyReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	n, err := x.rs.Seek(offset, whence)
+	if err == nil {
+		x.bar.SetCurrent(n)
+	}
+	return n, err
+}
+
+func (x proxyReadSeeker) Close() error {
+	if rc, ok := x.rs.(io.ReadCloser); ok {
+		return rc.Close()
+	}
+	return nil
+}
+
+type ewmaProxyReadSeeker struct {
+	rs  io.ReadSeeker
+	bar *Bar
+}
+
+func (x ewmaProxyReadSeeker) Read(p []byte) (int, error) {
+	start := time.Now()
+	n, err := x.rs.Read(p)
+	x.bar.EwmaIncrBy(n, time.Since(start))
+	return n, err
+}
+
+func (x ewmaProxyReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	n, err := x.rs.Seek(offset, whence)
+	if err == nil {
+		x.bar.EwmaSetCurrent(n, 0)
+	}
+	return n, err
+}
+
+func (x ewmaProxyReadSeeker) Close() error {
+	if rc, ok := x.rs.(io.ReadCloser); ok {
+		return rc.Close()
+	}
+	return nil
+}
+
+func newProxyReadSeeker(rs io.ReadSeeker, b *Bar, hasEwma bool) io.ReadSeekCloser {
+	if hasEwma {
+		return ewmaProxyReadSeeker{rs, b}
+	}
+	return proxyReadSeeker{rs, b}
+}

--- a/proxyreadseeker_test.go
+++ b/proxyreadseeker_test.go
@@ -1,0 +1,158 @@
+package mpb_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
+)
+
+func TestProxyReadSeeker(t *testing.T) {
+	p := mpb.New(mpb.WithOutput(io.Discard))
+	total := int64(len(content))
+	bar := p.AddBar(total,
+		mpb.AppendDecorators(decor.Percentage()),
+	)
+
+	rs := bar.ProxyReadSeeker(strings.NewReader(content))
+	if rs == nil {
+		t.Fatal("expected non-nil io.ReadSeekCloser")
+	}
+
+	buf := make([]byte, 32)
+	var read int64
+	for {
+		n, err := rs.Read(buf)
+		read += int64(n)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected read error: %v", err)
+		}
+	}
+
+	if read != total {
+		t.Errorf("read %d bytes, want %d", read, total)
+	}
+	if bar.Current() != total {
+		t.Errorf("bar.Current() = %d, want %d", bar.Current(), total)
+	}
+	p.Wait()
+}
+
+func TestProxyReadSeekerSeekRewind(t *testing.T) {
+	p := mpb.New(mpb.WithOutput(io.Discard))
+	total := int64(len(content))
+	bar := p.AddBar(total)
+
+	rs := bar.ProxyReadSeeker(strings.NewReader(content))
+
+	// Read half
+	half := total / 2
+	io.CopyN(io.Discard, rs, half)
+	if bar.Current() != half {
+		t.Errorf("after half read: bar.Current() = %d, want %d", bar.Current(), half)
+	}
+
+	// Seek back to start (simulates S3 retry)
+	pos, err := rs.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatalf("seek error: %v", err)
+	}
+	if pos != 0 {
+		t.Errorf("seek returned %d, want 0", pos)
+	}
+	if bar.Current() != 0 {
+		t.Errorf("after seek to start: bar.Current() = %d, want 0", bar.Current())
+	}
+
+	// Read everything again
+	io.Copy(io.Discard, rs)
+	if bar.Current() != total {
+		t.Errorf("after full re-read: bar.Current() = %d, want %d", bar.Current(), total)
+	}
+	p.Wait()
+}
+
+func TestProxyReadSeekerSeekEnd(t *testing.T) {
+	p := mpb.New(mpb.WithOutput(io.Discard))
+	total := int64(len(content))
+	bar := p.AddBar(total)
+
+	rs := bar.ProxyReadSeeker(strings.NewReader(content))
+
+	pos, err := rs.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("seek error: %v", err)
+	}
+	if pos != total {
+		t.Errorf("seek to end returned %d, want %d", pos, total)
+	}
+	if bar.Current() != total {
+		t.Errorf("after seek to end: bar.Current() = %d, want %d", bar.Current(), total)
+	}
+	bar.SetTotal(total, true)
+	p.Wait()
+}
+
+func TestProxyReadSeekerClose(t *testing.T) {
+	p := mpb.New(mpb.WithOutput(io.Discard))
+	total := int64(len(content))
+	bar := p.AddBar(total)
+
+	rc := &readSeekNopCloser{ReadSeeker: strings.NewReader(content)}
+	rs := bar.ProxyReadSeeker(rc)
+
+	// Read everything so the bar completes naturally
+	io.Copy(io.Discard, rs)
+
+	if err := rs.Close(); err != nil {
+		t.Fatalf("close error: %v", err)
+	}
+	if !rc.closed {
+		t.Error("expected underlying ReadCloser to be closed")
+	}
+	p.Wait()
+}
+
+func TestProxyReadSeekerNilPanics(t *testing.T) {
+	p := mpb.New(mpb.WithOutput(io.Discard))
+	bar := p.AddBar(10)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil ReadSeeker")
+		}
+	}()
+	bar.ProxyReadSeeker(nil)
+}
+
+func TestProxyReadSeekerDataIntegrity(t *testing.T) {
+	p := mpb.New(mpb.WithOutput(io.Discard))
+	total := int64(len(content))
+	bar := p.AddBar(total)
+
+	rs := bar.ProxyReadSeeker(strings.NewReader(content))
+
+	var buf bytes.Buffer
+	io.Copy(&buf, rs)
+
+	if buf.String() != content {
+		t.Error("proxied content does not match original")
+	}
+	p.Wait()
+}
+
+type readSeekNopCloser struct {
+	io.ReadSeeker
+	closed bool
+}
+
+func (r *readSeekNopCloser) Close() error {
+	r.closed = true
+	return nil
+}

--- a/proxyreadseeker_test.go
+++ b/proxyreadseeker_test.go
@@ -53,7 +53,7 @@ func TestProxyReadSeekerSeekRewind(t *testing.T) {
 
 	// Read half
 	half := total / 2
-	io.CopyN(io.Discard, rs, half)
+	_, _ = io.CopyN(io.Discard, rs, half)
 	if bar.Current() != half {
 		t.Errorf("after half read: bar.Current() = %d, want %d", bar.Current(), half)
 	}
@@ -71,7 +71,7 @@ func TestProxyReadSeekerSeekRewind(t *testing.T) {
 	}
 
 	// Read everything again
-	io.Copy(io.Discard, rs)
+	_, _ = io.Copy(io.Discard, rs)
 	if bar.Current() != total {
 		t.Errorf("after full re-read: bar.Current() = %d, want %d", bar.Current(), total)
 	}
@@ -108,7 +108,7 @@ func TestProxyReadSeekerClose(t *testing.T) {
 	rs := bar.ProxyReadSeeker(rc)
 
 	// Read everything so the bar completes naturally
-	io.Copy(io.Discard, rs)
+	_, _ = io.Copy(io.Discard, rs)
 
 	if err := rs.Close(); err != nil {
 		t.Fatalf("close error: %v", err)
@@ -139,7 +139,7 @@ func TestProxyReadSeekerDataIntegrity(t *testing.T) {
 	rs := bar.ProxyReadSeeker(strings.NewReader(content))
 
 	var buf bytes.Buffer
-	io.Copy(&buf, rs)
+	_, _ = io.Copy(&buf, rs)
 
 	if buf.String() != content {
 		t.Error("proxied content does not match original")


### PR DESCRIPTION
Adds `Bar.ProxyReadSeeker` as the `io.ReadSeeker` counterpart of `ProxyReader`.

**Motivation:** S3 multipart uploads (AWS SDK) require `io.ReadSeeker`, but `ProxyReader` only returns `io.ReadCloser`. This makes it impossible to wrap an upload body with progress tracking.

**Behavior:**
- `Read` increments the bar (same as ProxyReader)
- `Seek` resets the bar's current value to the new absolute offset, so the bar stays in sync after retries or rewinds
- `Close` delegates to the underlying reader if it implements `io.ReadCloser`
- EWMA decorators are supported (uses `EwmaIncrBy` / `EwmaSetCurrent`)

**Tests:** 6 tests covering full read, seek rewind (S3 retry simulation), seek to end, close delegation, nil panic, and data integrity.

Closes #114